### PR TITLE
fix: set JWT issuer to cluster URI

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,9 +49,7 @@ resource "vault_kubernetes_auth_backend_config" "cluster" {
   kubernetes_host    = "https://${var.cluster.endpoint}"
   kubernetes_ca_cert = base64decode(var.cluster.master_auth.0.cluster_ca_certificate)
   token_reviewer_jwt = data.kubernetes_secret.token_review.data["token"]
-  # issuer             = "kubernetes/serviceaccount"
-  # issuer             = "api"
-  # "iss": "kubernetes/serviceaccount",
+  issuer             = var.cluster.self_link
 }
 
 data "kubernetes_secret" "token_review" {


### PR DESCRIPTION
This fixes a breaking change from latest changes with Vault and Kubernetes. Context: https://particule.io/en/blog/vault-1.21/